### PR TITLE
Slow Subscribers: clarify datagram behavior, add cross-references

### DIFF
--- a/draft-englishm-moq-relay-dos.md
+++ b/draft-englishm-moq-relay-dos.md
@@ -487,7 +487,7 @@ of receiving and discarding them.
 
 A relay also cannot apply QUIC flow control backpressure
 to the upstream publisher on behalf of one slow subscriber
-without affecting all other subscribers on that track.
+without affecting other downstream subscribers of that track.
 
 Relays that detect and handle slow subscribers
 can limit this accumulation. Options include canceling

--- a/draft-englishm-moq-relay-dos.md
+++ b/draft-englishm-moq-relay-dos.md
@@ -455,10 +455,12 @@ and processing capacity for framing and scheduling.
 
 ## Slow Subscribers
 
-A subscriber that consumes data slower than it is produced
-causes data to accumulate at the relay.
-The relay must buffer objects waiting to be read,
-and that memory pressure could affect other subscribers
+Because a relay MUST NOT drop objects on a multi-object stream
+when forwarding to subscribers
+(see {{Section 9.4 of MOQT}}),
+a subscriber that consumes data more slowly than it is produced
+will cause data to accumulate at the relay.
+That memory pressure could affect other subscribers
 on the same relay
 (see {{flow-control-limitations}} and {{resource-isolation}}).
 This can happen because the subscriber's network is slow,
@@ -467,19 +469,29 @@ fast enough, or because the subscriber is deliberately
 not consuming data at all.
 
 Objects sent on QUIC streams are reliably delivered,
-so a slow subscriber causes unbounded buffering
-unless the relay intervenes.
+so the relay's only mechanism to bound buffering
+is to terminate the subscription entirely
+by resetting the stream.
+The relay cannot selectively drop individual objects
+while keeping the subscription active,
+which means any resource bound requires full termination —
+creating a denial-of-service risk
+where the only defense disrupts service.
 Objects sent as datagrams can simply be dropped
 when a buffer forms,
 which naturally limits accumulation
 but does not eliminate the processing cost
 of receiving and discarding them.
 
+A relay also cannot apply QUIC flow control backpressure
+to the upstream publisher on behalf of one slow subscriber
+without affecting all other subscribers on that track.
+
 Relays that detect and handle slow subscribers
 can limit this accumulation. Options include canceling
 subscriptions that fall too far behind the live edge,
-and imposing per-subscriber buffer limits.
-(see {{MOQT}}, Section 8)
+and imposing per-subscriber buffer limits
+(see {{Section 8 of MOQT}}).
 
 ## Join-Time Buffering
 

--- a/draft-englishm-moq-relay-dos.md
+++ b/draft-englishm-moq-relay-dos.md
@@ -455,9 +455,11 @@ and processing capacity for framing and scheduling.
 
 ## Slow Subscribers
 
-Because a relay MUST NOT drop objects on a multi-object stream
-when forwarding to subscribers
-(see {{Section 9.4 of MOQT}}),
+A relay MUST NOT reorder or drop objects
+on a multi-object stream when forwarding to subscribers,
+absent application-specific information
+(see {{Section 9.4 of MOQT}}).
+Without such information,
 a subscriber that consumes data more slowly than it is produced
 will cause data to accumulate at the relay.
 That memory pressure could affect other subscribers

--- a/draft-englishm-moq-relay-dos.md
+++ b/draft-englishm-moq-relay-dos.md
@@ -459,11 +459,21 @@ A subscriber that consumes data slower than it is produced
 causes data to accumulate at the relay.
 The relay must buffer objects waiting to be read,
 and that memory pressure could affect other subscribers
-on the same relay.
+on the same relay
+(see {{flow-control-limitations}} and {{resource-isolation}}).
 This can happen because the subscriber's network is slow,
 because the subscriber's application isn't consuming data
 fast enough, or because the subscriber is deliberately
 not consuming data at all.
+
+Objects sent on QUIC streams are reliably delivered,
+so a slow subscriber causes unbounded buffering
+unless the relay intervenes.
+Objects sent as datagrams can simply be dropped
+when a buffer forms,
+which naturally limits accumulation
+but does not eliminate the processing cost
+of receiving and discarding them.
 
 Relays that detect and handle slow subscribers
 can limit this accumulation. Options include canceling
@@ -497,7 +507,7 @@ a relay can cancel the subscription,
 skip ahead to the live edge,
 or reduce delivery quality.
 
-## Flow Control Limitations
+## Flow Control Limitations {#flow-control-limitations}
 
 QUIC flow control ({{Section 4 of RFC9000}}) protects receivers
 from memory exhaustion,
@@ -546,7 +556,7 @@ and publishers (to downstream subscribers).
 This dual role creates DoS considerations
 that don't apply to original publishers or end subscribers.
 
-## Resource Isolation
+## Resource Isolation {#resource-isolation}
 
 A relay serving multiple clients
 must prevent one client's behavior


### PR DESCRIPTION
Distinguishes between streams (unbounded buffering unless the relay intervenes) and datagrams (can be dropped, naturally limiting accumulation). Adds cross-references to Flow Control Limitations and Resource Isolation sections where the impact on other subscribers is covered.

Fixes #13